### PR TITLE
Bubble viewer events to the grauman facade

### DIFF
--- a/src/Grauman.js
+++ b/src/Grauman.js
@@ -2,6 +2,7 @@ import MediaPlayer from 'MediaPlayer';
 import ImageViewer from 'ImageViewer';
 import DocumentViewer from 'DocumentViewer';
 import MediaFile from 'MediaFile';
+import makeObservable from 'makeObservable';
 import { STEREOSCOPIC_LAYOUTS, IMAGEVIEWER_MODES, UPSCALE_MODES } from 'consts';
 import 'Grauman.scss';
 import 'tooltip.css';
@@ -17,6 +18,8 @@ class Grauman {
         if (!this.viewer) {
             // eslint-disable-next-line new-cap
             this.viewer = new this.type(this.container, { ...this.settings, file: this.file });
+
+            this.viewer.setEventBubbleTarget(this);
         }
 
         this.viewer.file = this.file;
@@ -79,6 +82,8 @@ class Grauman {
                 console.warn('Grauman does not have an acceptable viewer for MediaFile', this.file);
             }
         });
+
+        makeObservable(this);
 
         this.viewer = null;
         this.container = container;

--- a/src/Grauman.js
+++ b/src/Grauman.js
@@ -19,7 +19,7 @@ class Grauman {
             // eslint-disable-next-line new-cap
             this.viewer = new this.type(this.container, { ...this.settings, file: this.file });
 
-            this.viewer.setEventBubbleTarget(this);
+            this.viewer.setEventTarget(this);
         }
 
         this.viewer.file = this.file;

--- a/src/makeObservable.js
+++ b/src/makeObservable.js
@@ -2,6 +2,9 @@ export default function makeObservable(obj) {
     // internal hash that will track all of the event handlers bound through the `on` method
     const _observers = {};
 
+    // parent object that should receive bubbled events
+    let _bubbleTarget = null;
+
     /**
      * Attach an event callback function to this instance.
      *
@@ -76,5 +79,22 @@ export default function makeObservable(obj) {
                 callback.call(this, event);
             }, this);
         }
+
+        if (_bubbleTarget && typeof _bubbleTarget._notify === 'function') {
+            _bubbleTarget._notify(eventName, event);
+        }
+    }.bind(obj);
+
+    /**
+     * Set object that will receive bubbled events
+     *
+     * @param {object} target Events receiver
+     */
+    obj.setEventBubbleTarget = function (target) {
+        if (typeof target !== 'object' || typeof target._notify !== 'function') {
+            throw new TypeError('Bubble target should be an observable object');
+        }
+
+        _bubbleTarget = target;
     }.bind(obj);
 }

--- a/src/makeObservable.js
+++ b/src/makeObservable.js
@@ -2,8 +2,8 @@ export default function makeObservable(obj) {
     // internal hash that will track all of the event handlers bound through the `on` method
     const _observers = {};
 
-    // parent object that should receive bubbled events
-    let _bubbleTarget = null;
+    // "parent" object that should receive bubbled events
+    let _eventTarget = null;
 
     /**
      * Attach an event callback function to this instance.
@@ -80,8 +80,8 @@ export default function makeObservable(obj) {
             }, this);
         }
 
-        if (_bubbleTarget && typeof _bubbleTarget._notify === 'function') {
-            _bubbleTarget._notify(eventName, event);
+        if (_eventTarget && typeof _eventTarget._notify === 'function') {
+            _eventTarget._notify(eventName, event);
         }
     }.bind(obj);
 
@@ -90,11 +90,18 @@ export default function makeObservable(obj) {
      *
      * @param {object} target Events receiver
      */
-    obj.setEventBubbleTarget = function (target) {
+    obj.setEventTarget = function (target) {
         if (typeof target !== 'object' || typeof target._notify !== 'function') {
-            throw new TypeError('Bubble target should be an observable object');
+            throw new TypeError('Event target should be an observable object');
         }
 
-        _bubbleTarget = target;
+        _eventTarget = target;
+    }.bind(obj);
+
+    /**
+     * Stop sending events to another object
+     */
+    obj.clearEventTarget = function () {
+        _eventTarget = null;
     }.bind(obj);
 }


### PR DESCRIPTION
Allows to attach listener once, without having to detach\reattach every time when viewer is changed