### PR TITLE
Fixes of play button alert when autoplay fails

### DIFF
--- a/src/Grauman.scss
+++ b/src/Grauman.scss
@@ -6,7 +6,7 @@
         font-family: sans-serif;
         position: absolute;
         color: $textColor;
-        top: 50%;
+        top: 47%;
         left: 50%;
         transform: translate(-50%, -50%);
         background-color: $alertBackgroundColor;

--- a/src/ImageViewer.js
+++ b/src/ImageViewer.js
@@ -133,7 +133,8 @@ export default class ImageViewer {
                     file: instance.file,
                     isFullscreenEnabled: instance.isFullscreenEnabled,
                     viewMode: instance.viewMode,
-                    onViewModeChange: instance._onViewModeChange
+                    onViewModeChange: instance._onViewModeChange,
+                    _nativeEventForwarder: function _eventForwarder(e) { instance._notify(e.type, e); }.bind(instance)
                 }));
             }
         });

--- a/src/components/ImageViewer.js
+++ b/src/components/ImageViewer.js
@@ -230,7 +230,7 @@ const ImageViewerComponent = {
 
         const position = this.position;
         const styles = {
-            'background-image': `url(${this.image.src})`
+            'background-image': `url("${this.image.src.replace(/(")/g, "\\$1")}")`
         };
 
         let positionX = 'center',

--- a/src/components/ImageViewer.js
+++ b/src/components/ImageViewer.js
@@ -20,6 +20,7 @@ const ImageViewerComponent = {
     isHidingControls: false,
     isLockingControls: false,
     isFullscreen: false,
+    isBodyFullscreen: false,
 
     position: [0, 0],
     lastMousePosition: [0, 0],
@@ -48,6 +49,7 @@ const ImageViewerComponent = {
             document.msFullscreenElement;
 
         this.isFullscreen = (element && vnode.dom.contains(element)) || false;
+        this.isBodyFullscreen = element || false;
         this.redraw();
     },
 
@@ -151,6 +153,8 @@ const ImageViewerComponent = {
     },
 
     oninit: function (vnode) {
+        this._nativeEventForwarder = typeof vnode.attrs._nativeEventForwarder === 'function' ?
+            vnode.attrs._nativeEventForwarder : false;
         this.onDocumentMouseMove = this.onDocumentMouseMove.bind(this, vnode);
         this.onDocumentMouseUp = this.onDocumentMouseUp.bind(this, vnode);
         this.onElementResize = this.onElementResize.bind(this, vnode);
@@ -199,6 +203,7 @@ const ImageViewerComponent = {
 
         this.loadImage(vnode.attrs.file);
         document.addEventListener(FULLSCREEN_EVENT_NAME, this.onFullscreenChange);
+        this._nativeEventForwarder(new Event('created'));
     },
 
     onremove: function (/* vnode */) {
@@ -249,20 +254,24 @@ const ImageViewerComponent = {
     },
 
     toggleFullscreen(vnode) {
-        const container = vnode.dom;
+        let fullscreenToggle = new Event('fullscreenToggle');
+        this._nativeEventForwarder(fullscreenToggle);
+        if (!fullscreenToggle.cancelBubble) {
+            const container = vnode.dom;
 
-        if (this.isFullscreen) {
-            const exitFullscreen = document.exitFullscreen ||
-                document.mozCancelFullScreen ||
-                document.webkitExitFullscreen;
+            if (this.isFullscreen) {
+                const exitFullscreen = document.exitFullscreen ||
+                    document.mozCancelFullScreen ||
+                    document.webkitExitFullscreen;
 
-            exitFullscreen.apply(document);
-        } else {
-            const requestFullscreen = container.requestFullScreen ||
-                container.webkitRequestFullScreen ||
-                container.mozRequestFullScreen;
+                exitFullscreen.apply(document);
+            } else {
+                const requestFullscreen = container.requestFullScreen ||
+                    container.webkitRequestFullScreen ||
+                    container.mozRequestFullScreen;
 
-            requestFullscreen.apply(container);
+                requestFullscreen.apply(container);
+            }
         }
     },
 
@@ -333,8 +342,8 @@ const ImageViewerComponent = {
                 }, [
                     m('i', {
                         class: classnames({
-                            'icon-expand-16': !this.isFullscreen,
-                            'icon-compress-16': this.isFullscreen
+                            'icon-expand-16': !this.isFullscreen || !this.isBodyFullscreen,
+                            'icon-compress-16': this.isFullscreen || this.isBodyFullscreen
                         })
                     })
                 ]) : ''

--- a/src/components/MediaControls/Scrubber.js
+++ b/src/components/MediaControls/Scrubber.js
@@ -4,6 +4,7 @@ import throttle from 'lodash.throttle';
 import Polyfills from 'Polyfills';
 import TimeFormatter from 'TimeFormatter';
 import './Scrubber.scss';
+import { IS_MOBILE } from 'consts';
 
 function _matches(el, selector) {
     return (
@@ -92,6 +93,12 @@ const Scrubber = {
                 return;
             }
         }
+
+        const boundingRect = vnode.dom.getBoundingClientRect();
+        const cursorX = Math.max(0, e.touches[0].clientX - boundingRect.left);
+        const width = parseInt(vnode.dom.offsetWidth, 10);
+
+        this.cursorX = Math.min(cursorX, width);
 
         this.isDragging = true;
 

--- a/src/components/MediaPlayer.js
+++ b/src/components/MediaPlayer.js
@@ -39,6 +39,7 @@ const MediaPlayerComponent = {
     showNotification: false, // TODO: move to independent viewers
     notificationType: null, // TODO: move witwh showNotification
     _resizeSensor: null, // TODO: move resizeSensor logic into class mixin
+    autoplayFailed: false, // Autoplay failed - show alert
 
     _attachResizeSensor() {
         if (!this._resizeSensor) {
@@ -159,21 +160,29 @@ const MediaPlayerComponent = {
         this.redraw();
     },
 
-    play(notify) {
+    play(notify, isAutoplayTriggered) {
         this.needsUserTrigger = false;
         this.showPosterImage = false;
         const media = this.mediaElement;
-
         if (this.isError) {
             media.load();
         } else if (this.isEnded) {
             this.currentTime = 0;
             media.currentTime = 0;
             media.play();
-            notify && this.notify('play');
         } else if (this.isPaused) {
-            media.play();
-            notify && this.notify('play');
+            let playPromise = media.play();
+            if (playPromise !== undefined) {
+                playPromise.then(function() {
+                    notify && this.notify('play');
+                    this.autoplayFailed = false;
+                }.bind(this)).catch(function(error) {
+                    if (isAutoplayTriggered) {
+                        this.autoplayFailed = true;
+                        this.redraw();
+                    }
+                }.bind(this));
+            }
         } else {
             media.pause();
             notify && this.notify('pause');
@@ -398,7 +407,7 @@ const MediaPlayerComponent = {
             this.isInitialLoad = false;
 
             if (this.autoplay) {
-                this.play();
+                this.play(false, true);
             }
         }
     },
@@ -618,7 +627,7 @@ const MediaPlayerComponent = {
         }
 
         // TODO: this if condition... jesus christ.
-        if (this.needsUserTrigger || (this.file.mimeType.split('/')[0] !== 'audio' && !this.autoplay && this.currentTime === 0 && !this.isLoading && !this.isPlaying && !this.isError && !this.isEnded)) {
+        if (this.autoplayFailed || this.needsUserTrigger || (this.file.mimeType.split('/')[0] !== 'audio' && !this.autoplay && this.currentTime === 0 && !this.isLoading && !this.isPlaying && !this.isError && !this.isEnded)) {
             Alert = m(PlayAlert, { onTogglePlay: () => { this.play(); } } );
         }
 

--- a/src/components/alerts/Play.js
+++ b/src/components/alerts/Play.js
@@ -1,10 +1,11 @@
 import m from 'mithril';
 
 const PlayAlert = {
-    view(/* vnode */) {
+    view(vnode) {
         return m('div', {
-            class: 'icon-container'
-        }, m('i.icon-play'));
+            onclick: vnode.attrs.onTogglePlay,
+            class: 'icon-container-wrapper'
+        }, m('div.icon-container',{} , m('i.icon-play')));
     }
 };
 

--- a/src/components/alerts/PlayPause.scss
+++ b/src/components/alerts/PlayPause.scss
@@ -13,7 +13,7 @@
         width: 52px;
         height: 52px;
         z-index: 100;
-        margin-top: -26px;
+        margin-top: -42px;
         margin-left: -26px;
         margin-right: -26px;
         background: rgba(0,0,0,.5);

--- a/src/components/alerts/PlayPause.scss
+++ b/src/components/alerts/PlayPause.scss
@@ -1,6 +1,11 @@
 @import '../../variables.scss';
 
 .grauman-media-player {
+    .icon-container-wrapper {
+        position:absolute;
+        width: 100%;
+        height: 100%;
+    }
     .icon-container {
         position: absolute;
         left: 50%;

--- a/src/components/viewers/Audio.js
+++ b/src/components/viewers/Audio.js
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import TimeFormatter from 'TimeFormatter';
 import Polyfills from 'Polyfills';
 import './Audio.scss';
+import { IS_MOBILE } from 'consts';
 
 const AudioViewer = {
     isHovering: false,
@@ -67,6 +68,7 @@ const AudioViewer = {
     },
 
     _onDocumentMouseUp(vnode) {
+        IS_MOBILE && this.onupdate(vnode);
         this.isDragging = false;
         vnode.attrs.onSeek(this.hoverTime);
         Polyfills.closest(vnode.dom, '.media-container').focus();
@@ -82,7 +84,10 @@ const AudioViewer = {
 
         return m('.viewer', {
             style: { 'background-color': '#fff' },
-            onclick: () => { vnode.attrs.onSeek(this.hoverTime); },
+            onclick: () => {
+                IS_MOBILE && this.onupdate(vnode);
+                vnode.attrs.onSeek(this.hoverTime);
+            },
             onmousemove: this._onMouseMove.bind(this, vnode),
             onmouseenter: this._onMouseEnter.bind(this, vnode),
             onmousedown: this._onMouseDown.bind(this, vnode),


### PR DESCRIPTION
Show play button alert if triggered by autoPlay play() promise failed (due to Chrome/Safari autoplay policy changes)
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

Fixed container of play button, added overlay that takes full height and width of parent
Fixed position of play button to be at center taking into account player controls
Fixed position of loader to be at center taking into account player controls