### PR TITLE
Fixes of play button alert when autoplay fails

### DIFF
--- a/src/Grauman.scss
+++ b/src/Grauman.scss
@@ -6,7 +6,7 @@
         font-family: sans-serif;
         position: absolute;
         color: $textColor;
-        top: 50%;
+        top: 47%;
         left: 50%;
         transform: translate(-50%, -50%);
         background-color: $alertBackgroundColor;

--- a/src/components/MediaPlayer.js
+++ b/src/components/MediaPlayer.js
@@ -39,6 +39,7 @@ const MediaPlayerComponent = {
     showNotification: false, // TODO: move to independent viewers
     notificationType: null, // TODO: move witwh showNotification
     _resizeSensor: null, // TODO: move resizeSensor logic into class mixin
+    autoplayFailed: false, // Autoplay failed - show alert
 
     _attachResizeSensor() {
         if (!this._resizeSensor) {
@@ -159,21 +160,29 @@ const MediaPlayerComponent = {
         this.redraw();
     },
 
-    play(notify) {
+    play(notify, isAutoplayTriggered) {
         this.needsUserTrigger = false;
         this.showPosterImage = false;
         const media = this.mediaElement;
-
         if (this.isError) {
             media.load();
         } else if (this.isEnded) {
             this.currentTime = 0;
             media.currentTime = 0;
             media.play();
-            notify && this.notify('play');
         } else if (this.isPaused) {
-            media.play();
-            notify && this.notify('play');
+            let playPromise = media.play();
+            if (playPromise !== undefined) {
+                playPromise.then(function() {
+                    notify && this.notify('play');
+                    this.autoplayFailed = false;
+                }.bind(this)).catch(function(error) {
+                    if (isAutoplayTriggered) {
+                        this.autoplayFailed = true;
+                        this.redraw();
+                    }
+                }.bind(this));
+            }
         } else {
             media.pause();
             notify && this.notify('pause');
@@ -398,7 +407,7 @@ const MediaPlayerComponent = {
             this.isInitialLoad = false;
 
             if (this.autoplay) {
-                this.play();
+                this.play(false, true);
             }
         }
     },
@@ -618,7 +627,7 @@ const MediaPlayerComponent = {
         }
 
         // TODO: this if condition... jesus christ.
-        if (this.needsUserTrigger || (this.file.mimeType.split('/')[0] !== 'audio' && !this.autoplay && this.currentTime === 0 && !this.isLoading && !this.isPlaying && !this.isError && !this.isEnded)) {
+        if (this.autoplayFailed || this.needsUserTrigger || (this.file.mimeType.split('/')[0] !== 'audio' && !this.autoplay && this.currentTime === 0 && !this.isLoading && !this.isPlaying && !this.isError && !this.isEnded)) {
             Alert = m(PlayAlert, { onTogglePlay: () => { this.play(); } } );
         }
 

--- a/src/components/alerts/Play.js
+++ b/src/components/alerts/Play.js
@@ -1,10 +1,11 @@
 import m from 'mithril';
 
 const PlayAlert = {
-    view(/* vnode */) {
+    view(vnode) {
         return m('div', {
-            class: 'icon-container'
-        }, m('i.icon-play'));
+            onclick: vnode.attrs.onTogglePlay,
+            class: 'icon-container-wrapper'
+        }, m('div.icon-container',{} , m('i.icon-play')));
     }
 };
 

--- a/src/components/alerts/PlayPause.scss
+++ b/src/components/alerts/PlayPause.scss
@@ -13,7 +13,7 @@
         width: 52px;
         height: 52px;
         z-index: 100;
-        margin-top: -26px;
+        margin-top: -42px;
         margin-left: -26px;
         margin-right: -26px;
         background: rgba(0,0,0,.5);

--- a/src/components/alerts/PlayPause.scss
+++ b/src/components/alerts/PlayPause.scss
@@ -1,6 +1,11 @@
 @import '../../variables.scss';
 
 .grauman-media-player {
+    .icon-container-wrapper {
+        position:absolute;
+        width: 100%;
+        height: 100%;
+    }
     .icon-container {
         position: absolute;
         left: 50%;


### PR DESCRIPTION
Show play button alert if triggered by autoPlay play() promise failed (due to Chrome/Safari autoplay policy changes)
https://developers.google.com/web/updates/2017/09/autoplay-policy-changes

Fixed container of play button, added overlay that takes full height and width of parent
Fixed position of play button to be at center taking into account player controls
Fixed position of loader to be at center taking into account player controls